### PR TITLE
fix: serve sitemap at /sitemap.xml/ on GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "start": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/gh-pages-sitemap.mjs",
     "preview": "npx serve out",
     "deploy": "npm run build && gh-pages -d out"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://adelsoft.co/sitemap.xml
+Sitemap: https://adelsoft.co/sitemap.xml/

--- a/scripts/gh-pages-sitemap.mjs
+++ b/scripts/gh-pages-sitemap.mjs
@@ -1,0 +1,21 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * GitHub Pages + trailingSlash: a file at /sitemap.xml makes /sitemap.xml/ 404.
+ * Convert the Next export file into a directory so both resolve:
+ *   /sitemap.xml  → redirect to /sitemap.xml/
+ *   /sitemap.xml/ → serves index.html (XML body)
+ */
+const outDir = path.resolve("out");
+const sitemapFile = path.join(outDir, "sitemap.xml");
+const sitemapDir = path.join(outDir, "sitemap.xml");
+const stagingFile = path.join(outDir, ".sitemap.xml.body");
+
+const xml = await readFile(sitemapFile, "utf8");
+await rename(sitemapFile, stagingFile);
+await mkdir(sitemapDir, { recursive: true });
+await writeFile(path.join(sitemapDir, "index.html"), xml, "utf8");
+await rm(stagingFile);
+
+console.log("Prepared out/sitemap.xml/ for GitHub Pages trailing-slash URLs");


### PR DESCRIPTION
## Summary
- With `trailingSlash: true`, GitHub Pages 404s on `/sitemap.xml/` when the sitemap is a single file
- Post-build step converts `out/sitemap.xml` into `out/sitemap.xml/index.html` so the trailing-slash URL works
- Point `robots.txt` at `https://adelsoft.co/sitemap.xml/`

## Test plan
- [ ] `npm run build` creates `out/sitemap.xml/index.html`
- [ ] After deploy, `https://adelsoft.co/sitemap.xml/` returns the XML sitemap
- [ ] `https://adelsoft.co/sitemap.xml` redirects or resolves to the same content


Made with [Cursor](https://cursor.com)